### PR TITLE
Fix for tree builder deprecation notice

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,9 +17,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
+        $tree = new TreeBuilder('stomp_php_stomp');
 
-        $root = $tree->root('stomp_php_stomp');
+        if (method_exists($tree, 'getRootNode')) {
+            $root = $tree->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $root = $tree->root('stomp_php_stomp');
+        }
 
         $this->addConnections($root);
         $this->addConsumers($root);


### PR DESCRIPTION
As of Symfony 4.2 Symfony\Component\Config\Definition\Builder\TreeBuilder constructor required root name otherwise it outputs the following notice "A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0."

Refer to documentation here: https://symfony.com/blog/new-in-symfony-4-2-important-deprecations